### PR TITLE
Use the new Elasticsearch client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
 language: node_js
 
 node_js:
-  - "9"
-  - "8"
-  - "6"
+  - "12"
   - "10"
+  - "8"
 
 services:
   - elasticsearch

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018 Fastify
+Copyright (c) 2018-2019 Fastify
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npm i fastify-elasticsearch
 
 ## Usage
 Add it to your project with `register` and you are done!  
-The plugins accepts the same options of the client.
+The plugin accepts the [same options](https://github.com/elastic/elasticsearch-js#client-options) of the client.
 
 ```js
 const fastify = require('fastify')()

--- a/README.md
+++ b/README.md
@@ -22,12 +22,14 @@ const fastify = require('fastify')()
 fastify.register(require('fastify-elasticsearch'), { node: 'http://localhost:9200' })
 
 fastify.get('/user', async function (req, reply) {
-  const { body } = this.elastic.search({
+  const { body } = await this.elastic.search({
     index: 'tweets',
     body: {
       query: { match: { text: req.query.q }}
     }
   })
+
+  return body.hits.hits
 })
 
 fastify.listen(3000, err => {
@@ -50,12 +52,14 @@ fastify.register(require('fastify-elasticsearch'), {
 })
 
 fastify.get('/user', async function (req, reply) {
-  const { body } = this.elastic.cluster1.search({
+  const { body } = await this.elastic.cluster1.search({
     index: 'tweets',
     body: {
       query: { match: { text: req.query.q }}
     }
   })
+
+  return body.hits.hits
 })
 
 fastify.listen(3000, err => {
@@ -75,12 +79,14 @@ fastify.register(require('fastify-elasticsearch'), {
 })
 
 fastify.get('/user', async function (req, reply) {
-  const { body } = this.elastic.search({
+  const { body } = await this.elastic.search({
     index: 'tweets',
     body: {
       query: { match: { text: req.query.q }}
     }
   })
+
+  return body.hits.hits
 })
 
 fastify.listen(3000, err => {

--- a/es-docker.sh
+++ b/es-docker.sh
@@ -7,6 +7,4 @@ exec docker run \
   --rm \
   -e "discovery.type=single-node" \
   -p 9200:9200 \
-  --network=elastic \
-  --name=elasticsearch \
   docker.elastic.co/elasticsearch/elasticsearch:7.1.0

--- a/es-docker.sh
+++ b/es-docker.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# run this file to get a working ES instance
+# for running the test locally
+
+exec docker run \
+  --rm \
+  -e "discovery.type=single-node" \
+  -p 9200:9200 \
+  --network=elastic \
+  --name=elasticsearch \
+  docker.elastic.co/elasticsearch/elasticsearch:7.1.0

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "lint": "standard | snazzy",
     "unit": "tap test.js",
-    "coverage": "tap --cov test.js",
     "test": "npm run lint && npm run unit"
   },
   "repository": {
@@ -21,20 +20,20 @@
     "ES"
   ],
   "author": "Tommaso Allevi - @allevo",
-  "license": "MIT",
+  "lrcense": "MIT",
   "bugs": {
     "url": "https://github.com/fastify/fastify-elasticsearch/issues"
   },
   "homepage": "https://github.com/fastify/fastify-elasticsearch#readme",
   "dependencies": {
-    "elasticsearch": "^15.2.0",
-    "fastify-plugin": "^1.2.1"
+    "@elastic/elasticsearch": "^7.1.0",
+    "fastify-plugin": "^1.6.0"
   },
   "devDependencies": {
-    "fastify": "^2.0.0",
+    "fastify": "^2.4.1",
     "pre-commit": "^1.2.2",
     "snazzy": "^8.0.0",
     "standard": "^12.0.1",
-    "tap": "^12.1.0"
+    "tap": "^14.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "ES"
   ],
   "author": "Tommaso Allevi - @allevo",
-  "lrcense": "MIT",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/fastify/fastify-elasticsearch/issues"
   },

--- a/test.js
+++ b/test.js
@@ -73,3 +73,16 @@ test('custom client', async t => {
   t.strictEqual(fastify.elastic.name, 'custom')
   await fastify.close()
 })
+
+test('Missing configuration', async t => {
+  const fastify = Fastify()
+  fastify.register(fastifyElasticsearch)
+
+  try {
+    await fastify.ready()
+    t.fail('should not boot successfully')
+  } catch (err) {
+    t.ok(err)
+    await fastify.close()
+  }
+})

--- a/test.js
+++ b/test.js
@@ -5,46 +5,41 @@ const { Client } = require('@elastic/elasticsearch')
 const Fastify = require('fastify')
 const fastifyElasticsearch = require('./index')
 
-test('with reachable cluster', t => {
+test('with reachable cluster', async t => {
   const fastify = Fastify()
   fastify.register(fastifyElasticsearch, { node: 'http://localhost:9200' })
 
-  fastify.ready()
-    .then(() => {
-      t.strictEqual(fastify.elastic.name, 'elasticsearch-js')
-      fastify.close(() => t.end())
-    })
-    .catch(e => t.fail(e))
+  await fastify.ready()
+  t.strictEqual(fastify.elastic.name, 'elasticsearch-js')
+  await fastify.close()
 })
 
-test('with unreachable cluster', t => {
+test('with unreachable cluster', async t => {
   const fastify = Fastify()
   fastify.register(fastifyElasticsearch, { node: 'http://localhost:9201' })
 
-  fastify.ready()
-    .then(() => t.fail('should not boot successfully'))
-    .catch((err) => {
-      t.ok(err)
-      fastify.close(() => t.end())
-    })
+  try {
+    await fastify.ready()
+    t.fail('should not boot successfully')
+  } catch (err) {
+    t.ok(err)
+    await fastify.close()
+  }
 })
 
-test('namespaced', t => {
+test('namespaced', async t => {
   const fastify = Fastify()
   fastify.register(fastifyElasticsearch, {
     node: 'http://localhost:9200',
     namespace: 'cluster'
   })
 
-  fastify.ready()
-    .then(() => {
-      t.strictEqual(fastify.elastic.cluster.name, 'elasticsearch-js')
-      fastify.close(() => t.end())
-    })
-    .catch(e => t.fail(e))
+  await fastify.ready()
+  t.strictEqual(fastify.elastic.cluster.name, 'elasticsearch-js')
+  await fastify.close()
 })
 
-test('namespaced (errored)', t => {
+test('namespaced (errored)', async t => {
   const fastify = Fastify()
   fastify.register(fastifyElasticsearch, {
     node: 'http://localhost:9200',
@@ -56,15 +51,16 @@ test('namespaced (errored)', t => {
     namespace: 'cluster'
   })
 
-  fastify.ready()
-    .then(() => t.fail('should not boot successfully'))
-    .catch((err) => {
-      t.ok(err)
-      fastify.close(() => t.end())
-    })
+  try {
+    await fastify.ready()
+    t.fail('should not boot successfully')
+  } catch (err) {
+    t.ok(err)
+    await fastify.close()
+  }
 })
 
-test('custom client', t => {
+test('custom client', async t => {
   const client = new Client({
     node: 'http://localhost:9200',
     name: 'custom'
@@ -73,10 +69,7 @@ test('custom client', t => {
   const fastify = Fastify()
   fastify.register(fastifyElasticsearch, { client })
 
-  fastify.ready()
-    .then(() => {
-      t.strictEqual(fastify.elastic.name, 'custom')
-      fastify.close(() => t.end())
-    })
-    .catch(e => t.fail(e))
+  await fastify.ready()
+  t.strictEqual(fastify.elastic.name, 'custom')
+  await fastify.close()
 })

--- a/test.js
+++ b/test.js
@@ -1,56 +1,82 @@
 'use strict'
 
+const { test } = require('tap')
+const { Client } = require('@elastic/elasticsearch')
 const Fastify = require('fastify')
-const fastifyElasticSearch = require('./index')
-const t = require('tap')
+const fastifyElasticsearch = require('./index')
 
-const elasticsearch = require('elasticsearch')
+test('with reachable cluster', t => {
+  const fastify = Fastify()
+  fastify.register(fastifyElasticsearch, { node: 'http://localhost:9200' })
 
-t.test('fastify-elasticsearch', t => {
-  t.test('with host and port', t => {
-    t.plan(2)
+  fastify.ready()
+    .then(() => {
+      t.strictEqual(fastify.elastic.name, 'elasticsearch-js')
+      fastify.close(() => t.end())
+    })
+    .catch(e => t.fail(e))
+})
 
-    const fastify = Fastify()
-    fastify.register(fastifyElasticSearch, { host: '127.0.0.1:9200' })
+test('with unreachable cluster', t => {
+  const fastify = Fastify()
+  fastify.register(fastifyElasticsearch, { node: 'http://localhost:9201' })
 
-    fastify.ready()
-      .then(() => {
-        t.ok(fastify.elasticsearch)
-        t.ok(fastify.elasticsearch.msearch)
-      })
-      .catch(e => t.fail(e))
+  fastify.ready()
+    .then(() => t.fail('should not boot successfully'))
+    .catch((err) => {
+      t.ok(err)
+      fastify.close(() => t.end())
+    })
+})
+
+test('namespaced', t => {
+  const fastify = Fastify()
+  fastify.register(fastifyElasticsearch, {
+    node: 'http://localhost:9200',
+    namespace: 'cluster'
   })
 
-  t.test('with the client', t => {
-    t.plan(1)
+  fastify.ready()
+    .then(() => {
+      t.strictEqual(fastify.elastic.cluster.name, 'elasticsearch-js')
+      fastify.close(() => t.end())
+    })
+    .catch(e => t.fail(e))
+})
 
-    const client = new elasticsearch.Client({ host: '127.0.0.1:9200' })
-
-    const fastify = Fastify()
-    fastify.register(fastifyElasticSearch, { client })
-
-    fastify.ready()
-      .then(() => {
-        t.equal(client, fastify.elasticsearch)
-      })
-      .catch(e => t.fail(e))
+test('namespaced (errored)', t => {
+  const fastify = Fastify()
+  fastify.register(fastifyElasticsearch, {
+    node: 'http://localhost:9200',
+    namespace: 'cluster'
   })
 
-  t.test('with unreachable cluster', t => {
-    t.plan(1)
-
-    const client = new elasticsearch.Client({ host: '127.0.0.1:9999' })
-
-    const fastify = Fastify()
-    fastify.register(fastifyElasticSearch, { client })
-
-    fastify.ready()
-      .then(() => t.fail('should not boot successfully'))
-      .catch((err) => {
-        t.equal(err.message, 'No Living connections')
-        fastify.close(() => t.end())
-      })
+  fastify.register(fastifyElasticsearch, {
+    node: 'http://localhost:9200',
+    namespace: 'cluster'
   })
 
-  t.end()
+  fastify.ready()
+    .then(() => t.fail('should not boot successfully'))
+    .catch((err) => {
+      t.ok(err)
+      fastify.close(() => t.end())
+    })
+})
+
+test('custom client', t => {
+  const client = new Client({
+    node: 'http://localhost:9200',
+    name: 'custom'
+  })
+
+  const fastify = Fastify()
+  fastify.register(fastifyElasticsearch, { client })
+
+  fastify.ready()
+    .then(() => {
+      t.strictEqual(fastify.elastic.name, 'custom')
+      fastify.close(() => t.end())
+    })
+    .catch(e => t.fail(e))
 })


### PR DESCRIPTION
As titled!
In addition, I've added the support for custom namespaces as we did for the MongoDB and Redis plugins and updated the default namespace to something shorter.

Yes, this is a breaking change.