### PR TITLE
Make the healthcheck optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,14 @@ fastify.listen(3000, err => {
 })
 ```
 
+By default, `fastify-elasticsearch` will try to ping the cluster as soon as you start Fastify, but in some cases pinging may not be supported due to the user permissions. If you want, you can disable the initial ping with the `healthcheck` option:
+```js
+fastify.register(require('fastify-elasticsearch'), {
+  node: 'http://localhost:9200',
+  healthcheck: false
+})
+```
+
 If you need to connect to different clusters, you can also pass a `namespace` option:
 ```js
 const fastify = require('fastify')()

--- a/es-docker.sh
+++ b/es-docker.sh
@@ -7,4 +7,4 @@ exec docker run \
   --rm \
   -e "discovery.type=single-node" \
   -p 9200:9200 \
-  docker.elastic.co/elasticsearch/elasticsearch:7.1.0
+  docker.elastic.co/elasticsearch/elasticsearch:7.4.0

--- a/index.js
+++ b/index.js
@@ -4,12 +4,15 @@ const fp = require('fastify-plugin')
 const { Client } = require('@elastic/elasticsearch')
 
 async function fastifyElasticsearch (fastify, options) {
-  const { namespace } = options
+  const { namespace, healthcheck } = options
   delete options.namespace
+  delete options.healthcheck
 
   const client = options.client || new Client(options)
 
-  await client.ping()
+  if (healthcheck !== false) {
+    await client.ping()
+  }
 
   if (namespace) {
     if (!fastify.elastic) {

--- a/test.js
+++ b/test.js
@@ -27,6 +27,22 @@ test('with unreachable cluster', async t => {
   }
 })
 
+test('with unreachable cluster and healthcheck disabled', async t => {
+  const fastify = Fastify()
+  fastify.register(fastifyElasticsearch, {
+    node: 'http://localhost:9201',
+    healthcheck: false
+  })
+
+  try {
+    await fastify.ready()
+    t.strictEqual(fastify.elastic.name, 'elasticsearch-js')
+  } catch (err) {
+    t.fail('should not error')
+  }
+  await fastify.close()
+})
+
 test('namespaced', async t => {
   const fastify = Fastify()
   fastify.register(fastifyElasticsearch, {


### PR DESCRIPTION
By default, `fastify-elasticsearch` will try to ping the cluster as soon as you start Fastify, but in some cases, pinging may not be supported due to the user permissions.
This pr adds a new option to disable that initial ping.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
