### PR TITLE
build(deps): upgrade to elastisearch 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,6 @@ jobs:
     strategy:
       matrix:
         node-version: [14, 16, 18]
-    services:
-      elasticsearch:
-        image: docker.elastic.co/elasticsearch/elasticsearch:7.10.0
-        ports:
-          - '9200:9200'
-        env:
-          discovery.type: single-node
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
@@ -50,6 +43,19 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
+
+      - name: Configure sysctl limits
+        run: |
+          sudo swapoff -a
+          sudo sysctl -w vm.swappiness=1
+          sudo sysctl -w fs.file-max=262144
+          sudo sysctl -w vm.max_map_count=262144
+
+      - name: Runs Elasticsearch
+        uses: elastic/elastic-github-actions/elasticsearch@master
+        with:
+          stack-version: 8.3.2
+          security-enabled: false
 
       - name: Install dependencies
         run: npm i --ignore-scripts

--- a/es-docker.sh
+++ b/es-docker.sh
@@ -6,5 +6,6 @@
 exec docker run \
   --rm \
   -e "discovery.type=single-node" \
+  -e "xpack.security.enabled=false" \
   -p 9200:9200 \
-  docker.elastic.co/elasticsearch/elasticsearch:7.4.0
+  docker.elastic.co/elasticsearch/elasticsearch:8.3.2

--- a/index.js
+++ b/index.js
@@ -25,14 +25,15 @@ async function fastifyElasticsearch (fastify, options) {
 
     fastify.elastic[namespace] = client
 
-    fastify.addHook('onClose', (instance, done) => {
-      instance.elastic[namespace].close(done)
+    fastify.addHook('onClose', async (instance) => {
+      // v8 client.close returns a promise and does not accept a callback
+      await instance.elastic[namespace].close()
     })
   } else {
     fastify
       .decorate('elastic', client)
-      .addHook('onClose', (instance, done) => {
-        instance.elastic.close(done)
+      .addHook('onClose', async (instance) => {
+        await instance.elastic.close()
       })
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/fastify/fastify-elasticsearch#readme",
   "dependencies": {
-    "@elastic/elasticsearch": "^7.1.0",
+    "@elastic/elasticsearch": "^8.2.1",
     "fastify-plugin": "^4.0.0"
   },
   "devDependencies": {

--- a/test.js
+++ b/test.js
@@ -7,15 +7,16 @@ const fastifyElasticsearch = require('./index')
 
 test('with reachable cluster', async t => {
   const fastify = Fastify()
+  t.teardown(() => fastify.close())
   fastify.register(fastifyElasticsearch, { node: 'http://localhost:9200' })
 
   await fastify.ready()
-  t.strictEqual(fastify.elastic.name, 'elasticsearch-js')
-  await fastify.close()
+  t.equal(fastify.elastic.name, 'elasticsearch-js')
 })
 
 test('with unreachable cluster', async t => {
   const fastify = Fastify()
+  t.teardown(() => fastify.close())
   fastify.register(fastifyElasticsearch, { node: 'http://localhost:9201' })
 
   try {
@@ -23,12 +24,12 @@ test('with unreachable cluster', async t => {
     t.fail('should not boot successfully')
   } catch (err) {
     t.ok(err)
-    await fastify.close()
   }
 })
 
 test('with unreachable cluster and healthcheck disabled', async t => {
   const fastify = Fastify()
+  t.teardown(() => fastify.close())
   fastify.register(fastifyElasticsearch, {
     node: 'http://localhost:9201',
     healthcheck: false
@@ -36,27 +37,27 @@ test('with unreachable cluster and healthcheck disabled', async t => {
 
   try {
     await fastify.ready()
-    t.strictEqual(fastify.elastic.name, 'elasticsearch-js')
+    t.equal(fastify.elastic.name, 'elasticsearch-js')
   } catch (err) {
     t.fail('should not error')
   }
-  await fastify.close()
 })
 
 test('namespaced', async t => {
   const fastify = Fastify()
+  t.teardown(() => fastify.close())
   fastify.register(fastifyElasticsearch, {
     node: 'http://localhost:9200',
     namespace: 'cluster'
   })
 
   await fastify.ready()
-  t.strictEqual(fastify.elastic.cluster.name, 'elasticsearch-js')
-  await fastify.close()
+  t.equal(fastify.elastic.cluster.name, 'elasticsearch-js')
 })
 
 test('namespaced (errored)', async t => {
   const fastify = Fastify()
+  t.teardown(() => fastify.close())
   fastify.register(fastifyElasticsearch, {
     node: 'http://localhost:9200',
     namespace: 'cluster'
@@ -72,7 +73,6 @@ test('namespaced (errored)', async t => {
     t.fail('should not boot successfully')
   } catch (err) {
     t.ok(err)
-    await fastify.close()
   }
 })
 
@@ -83,15 +83,16 @@ test('custom client', async t => {
   })
 
   const fastify = Fastify()
+  t.teardown(() => fastify.close())
   fastify.register(fastifyElasticsearch, { client })
 
   await fastify.ready()
-  t.strictEqual(fastify.elastic.name, 'custom')
-  await fastify.close()
+  t.equal(fastify.elastic.name, 'custom')
 })
 
 test('Missing configuration', async t => {
   const fastify = Fastify()
+  t.teardown(() => fastify.close())
   fastify.register(fastifyElasticsearch)
 
   try {
@@ -99,6 +100,5 @@ test('Missing configuration', async t => {
     t.fail('should not boot successfully')
   } catch (err) {
     t.ok(err)
-    await fastify.close()
   }
 })


### PR DESCRIPTION
This PR upgrades elasticsearch to 8 using [elasticsearch-js](https://github.com/elastic/elasticsearch-js) 8.2.1. The biggest change comparing to v7 is that client.close does not accept a callback but returns a promise.

CI was refactored to use [elastic/elastic-github-actions](https://github.com/elastic/elastic-github-actions) with disabled security instead of a service.

es-docker.sh was update to start local container with disabled security.

Tests were refactored by removing deprecated methods and using t.teardown instead of explicitly calling fastify.close()

Other outdated dependencies were not upgraded.

Closes #78 - thanks for a descriptive issue with hints.

#### Checklist

- [x] run `npm run test`
- [x] tests and/or benchmarks are included
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)