### PR TITLE
chore(deps): use elasticsearch version `8.15.2`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,8 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci-elasticsearch.yml@v4.2.0
+    uses: fastify/workflows/.github/workflows/plugins-ci-elasticsearch.yml@v5.0.1
     with:
       lint: true
       license-check: true
+      elasticsearch-version: 8.15.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   test:
-    uses: fastify/workflows/.github/workflows/plugins-ci-elasticsearch.yml@v5.0.1
+    uses: fastify/workflows/.github/workflows/plugins-ci-elasticsearch.yml@v5
     with:
       lint: true
       license-check: true

--- a/es-docker.sh
+++ b/es-docker.sh
@@ -8,4 +8,4 @@ exec docker run \
   -e "discovery.type=single-node" \
   -e "xpack.security.enabled=false" \
   -p 9200:9200 \
-  docker.elastic.co/elasticsearch/elasticsearch:8.3.2
+  docker.elastic.co/elasticsearch/elasticsearch:8.15.2


### PR DESCRIPTION
After the release of https://github.com/fastify/workflows/releases/tag/v5.0.1 triggered by the discussion in https://github.com/fastify/fastify-elasticsearch/pull/117 we can now update to `plugins-ci-elasticsearch.yml` `v5` in order to target the `8.15.2` version of elasticsearch.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` ~and `npm run benchmark`~ no benchmarks
- [x] tests ~and/or benchmarks are included~ no benchmarks
- [x] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
