### PR TITLE
fix: support Elasticsearch v8 and v9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  test-elasticsearch-8:
     permissions:
       contents: write
       pull-requests: write
@@ -31,4 +31,15 @@ jobs:
     with:
       lint: true
       license-check: true
-      elasticsearch-version: 8.15.2
+      elasticsearch-version: '8.19.19'
+
+  test-elasticsearch-9:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: fastify/workflows/.github/workflows/plugins-ci-elasticsearch.yml@ef591e2186785d5ab36b9fe6a79c7ce2f1d94e57 # v7.0.0
+    with:
+      lint: true
+      license-check: true
+      elasticsearch-version: '9.4.4'
+

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ fastify.listen({ port: 3000 }, err => {
 ```
 
 ## Versioning
+
+`@fastify/elasticsearch` supports Elasticsearch client versions 8 and 9.
+
 By default the latest and greatest version of the Elasticsearch client is used, see the [compatibility](https://www.elastic.co/docs/reference/elasticsearch/clients/javascript/installation#nodejs-support) table to understand if the embedded client is correct for you.
 If it is not, you can pass a custom client via the `client` option.
 ```js

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Under the hood, the official [elasticsearch](https://www.npmjs.com/package/@elas
 ## Install
 
 ```
-npm i @fastify/elasticsearch
+npm i @fastify/elasticsearch @elastic/elasticsearch
 ```
 
 ### Compatibility

--- a/es-docker.sh
+++ b/es-docker.sh
@@ -3,9 +3,15 @@
 # run this file to get a working ES instance
 # for running the test locally
 
+# ES_VERSION can be overridden:
+# ES_VERSION=8.19.19 ./es-docker.sh
+# ES_VERSION=9.4.4 ./es-docker.sh
+
+ES_VERSION="${ES_VERSION:-8.19.19}"
+
 exec docker run \
   --rm \
   -e "discovery.type=single-node" \
   -e "xpack.security.enabled=false" \
   -p 9200:9200 \
-  docker.elastic.co/elasticsearch/elasticsearch:8.15.2
+  "docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}"

--- a/package.json
+++ b/package.json
@@ -59,16 +59,19 @@
     }
   ],
   "dependencies": {
-    "@elastic/elasticsearch": "^9.0.2",
     "fastify-plugin": "^6.0.0"
   },
   "devDependencies": {
+    "@elastic/elasticsearch": "^9.0.2",
     "@types/node": "^26.0.1",
     "c8": "^12.0.0",
     "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "neostandard": "^0.13.0",
     "tstyche": "^7.0.0"
+  },
+  "peerDependencies": {
+    "@elastic/elasticsearch": "^8 || ^9"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Proposal:

- Adds support for Elasticsearch client versions 8 and 9.

   - Updates the Elasticsearch peer dependency to support v8 and v9
   - Adds CI coverage for Elasticsearch v8 and v9
   - Updates the README to document the supported client versions
   - Updated `es-docker.sh` to use Elasticsearch `v8.19.19` by default and support Elasticsearch `v9.4.4` via `ES_VERSION`. This script can be used to run a local Elasticsearch instance for testing.



Fixes #139